### PR TITLE
Add missing dependency, Mail::Sendmail

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,7 @@ WriteMakefile(
                      'Test::Simple' => 0.44,
                      'DBI' => 0,
                      'JSON::XS' => 0,
-                     'Parse::RecDescent' => 0
+                     'Parse::RecDescent' => 0,
+                     'Mail::Sendmail'   => 0
                     },
 );


### PR DESCRIPTION
Thanks for your work on this module.
Mail::Sendmail is required but not marked as a dependency:

https://rt.cpan.org/Public/Bug/Display.html?id=95876
